### PR TITLE
Motoko VS Code extension setup guide

### DIFF
--- a/docs/developer-docs/build/backend/access-control.md
+++ b/docs/developer-docs/build/backend/access-control.md
@@ -26,7 +26,7 @@ Before starting the tutorial, verify the following:
 
 - You have run at least one command that resulted in your `default` user identity being created. Your default user identity is stored globally for all projects in the `$HOME/.config/dfx/identity/` directory.
 
-- You have installed the Visual Studio Code plugin for Motoko as described in [Install the language editor plug-in](/developer-docs/setup/vs-code-plugin.md) if you are using Visual Studio Code as your IDE.
+- You have installed the Visual Studio Code plugin for Motoko as described in [VS Code extensions for IC development](/developer-docs/setup/vs-code.md) if you are using Visual Studio Code as your IDE.
 
 - You have stopped any local canister execution environment processes running on your computer.
 

--- a/docs/developer-docs/build/backend/explore-templates.md
+++ b/docs/developer-docs/build/backend/explore-templates.md
@@ -16,7 +16,7 @@ Before you start this tutorial, verify the following:
 
 -   You have downloaded and installed the SDK package as described in [Download and install](/developer-docs/build/install-upgrade-remove.mdx).
 
--   You have installed the Visual Studio Code plugin for Motoko as described in [Install the language editor plug-in](/developer-docs/setup/vs-code-plugin.md) if you are using Visual Studio Code as your IDE.
+-   You have installed the Visual Studio Code plugin for Motoko as described in [VS Code extensions for IC development](/developer-docs/setup/vs-code.md) if you are using Visual Studio Code as your IDE.
 
 -   You have stopped any local canister execution environment processes running on the local computer.
 

--- a/docs/developer-docs/build/frontend/custom-frontend.md
+++ b/docs/developer-docs/build/frontend/custom-frontend.md
@@ -14,7 +14,7 @@ Before starting the tutorial, verify the following:
 
 -   You have downloaded and installed the SDK package as described in [Download and install](/developer-docs/build/install-upgrade-remove.mdx).
 
--   You have installed the Visual Studio Code plugin for Motoko as described in [Install the language editor plug-in](/developer-docs/setup/vs-code-plugin.md) if you are using Visual Studio Code as your IDE.
+-   You have installed the Visual Studio Code plugin for Motoko as described in [VS Code extensions for IC development](/developer-docs/setup/vs-code.md) if you are using Visual Studio Code as your IDE.
 
 -   You have stopped any SDK processes running on the local computer.
 

--- a/docs/developer-docs/build/frontend/my-contacts.md
+++ b/docs/developer-docs/build/frontend/my-contacts.md
@@ -12,7 +12,7 @@ Before starting the tutorial, verify the following:
 
 -   You have downloaded and installed the SDK package as described in [Download and install](/developer-docs/build/install-upgrade-remove.mdx).
 
--   You have installed the Visual Studio Code plugin for Motoko as described in [Install the language editor plug-in](/developer-docs/setup/vs-code-plugin.md) if you are using Visual Studio Code as your IDE.
+-   You have installed the Visual Studio Code plugin for Motoko as described in [VS Code extensions for IC development](/developer-docs/setup/vs-code.md) if you are using Visual Studio Code as your IDE.
 
 -   You have stopped any local canister execution environment processes running on the local computer.
 

--- a/docs/developer-docs/build/lang-service-ide.md
+++ b/docs/developer-docs/build/lang-service-ide.md
@@ -14,7 +14,7 @@ For example, if you use Visual Studio Code (VSCode) or Emacs as your development
 
 <div class="note">
 
-Only the Visual Studio Code (VSCode) plugin extension is currently available for Motoko. For information about installing the plugin, see [Install the language editor plug-in](/developer-docs/setup/vs-code-plugin.md).
+Only the Visual Studio Code (VS Code) plugin extension is currently available for Motoko. For information about installing the plugin, see [VS Code extensions for IC development](/developer-docs/setup/vs-code.md).
 
 </div>
 

--- a/docs/developer-docs/setup/vs-code-plugin.md
+++ b/docs/developer-docs/setup/vs-code-plugin.md
@@ -1,3 +1,0 @@
-# Visual Studio Code plugin for Internet Computer
-
-This content is being edited.

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -14,6 +14,8 @@ Try the extension in your browser with a full-stack [Vite + React + Motoko](http
 
 ### Getting Started
 
+[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/dfinity-foundation.vscode-motoko?color=brightgreen&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
+
 Install the extension through the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko), or alternatively the [Extensions panel](https://code.visualstudio.com/docs/editor/extension-marketplace) in your VS Code project. 
 
 [VSCodium](https://vscodium.com/) users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
@@ -30,11 +32,17 @@ Below are the default key bindings for commonly used features supported in the e
 
 ### Other Features
 
-- Quickly convert between Motoko types using code snippets such as `array-2-buffer` or `principal-2-text`.
 - View type information and documentation by hovering over function names, imports, and other expressions.
+- Quickly convert between Motoko types using code snippets such as `array-2-buffer` or `principal-2-text`.
 - In case you're hoping to learn Motoko without installing `dfx`, the Motoko VS Code extension works standalone on all major operating systems (including Windows). 
 - This extension also provides schema validation and autocompletion for `dfx.json` config files.
 - [Vessel](https://github.com/dfinity/vessel) and [MOPS](https://mops.one/) (the two most popular Motoko package managers) are supported out-of-the-box in this extension. 
+
+### Contributing
+
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?logo=github)](https://github.com/dfinity/prettier-plugin-motoko)
+
+The Motoko VS Code extension is completely open-source and [available on GitHub](https://github.com/dfinity/vscode-motoko). 
 
 ## Rust
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -8,7 +8,7 @@ The [Motoko VS Code extension](https://github.com/dfinity/vscode-motoko) provide
 
 [![Showcase](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/intro.webp)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 
-Try the extension online with a full-stack [Vite + React + Motoko](https://github.com/rvanasa/vite-react-motoko#readme) starter project:
+Try the extension in your browser with a full-stack [Vite + React + Motoko](https://github.com/rvanasa/vite-react-motoko#readme) starter project:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rvanasa/vite-react-motoko)
 
@@ -30,10 +30,11 @@ Below are the default key bindings for commonly used features supported in the e
 
 ### Other Features
 
-- The Motoko VS Code extension also provides schema validation and autocompletion for `dfx.json` files.
-- Hover over almost anything to view type information and/or explanations from `///` doc comments.
-- The extension automatically detects Motoko packages from [MOPS](https://mops.one/) and [Vessel](https://github.com/dfinity/vessel) config files. 
-- In case you're hoping to learn Motoko without downloading `dfx`, the Motoko VS Code extension works on all major operating systems (including Windows). 
+- Quickly convert between Motoko types using code snippets such as `array-2-buffer` or `principal-2-text`.
+- View type information and documentation by hovering over function names, imports, and other expressions.
+- In case you're hoping to learn Motoko without installing `dfx`, the Motoko VS Code extension works standalone on all major operating systems (including Windows). 
+- This extension also provides schema validation and autocompletion for `dfx.json` config files.
+- [Vessel](https://github.com/dfinity/vessel) and [MOPS](https://mops.one/) (the two most popular Motoko package managers) are supported out-of-the-box in this extension. 
 
 ## Rust
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -1,0 +1,21 @@
+# VS Code extensions for Internet Computer developers
+
+Visual Studio (VS) Code is a [widely used](https://survey.stackoverflow.co/2022/#section-worked-with-vs-want-to-work-with-integrated-development-environment) open-source IDE which supports canister development in [Motoko](https://internetcomputer.org/docs/current/developer-docs/build/cdks/motoko-dfinity/motoko/) or [Rust](https://www.rust-lang.org/).
+
+## Motoko
+
+[![Showcase](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/intro.webp)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
+
+The [Motoko VS Code extension](https://github.com/dfinity/vscode-motoko) provides type checking, formatting, autocompletion, go-to-definition, code snippets, and more for Motoko canister development.
+
+### Getting Started
+
+Install the extension through the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko), or alternatively the [Extensions panel](https://code.visualstudio.com/docs/editor/extension-marketplace) in your VS Code project. VSCodium users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
+
+### Feature Overview
+
+TODO
+
+## Rust
+
+Please refer to the official [Rust in Visual Studio Code](https://code.visualstudio.com/docs/languages/rust) documentation to configure your workspace for developing Rust canisters.

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -14,6 +14,10 @@ Install the extension through the [VS Marketplace](https://marketplace.visualstu
 
 [VSCodium](https://vscodium.com/) users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
 
+Alternatively, try out the extension online in this full-stack [Vite + React + Motoko](https://github.com/rvanasa/vite-react-motoko#readme) starter project:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rvanasa/vite-react-motoko)
+
 ### Keyboard Shortcuts
 
 Below are the default key bindings for commonly used features supported in the extension:
@@ -26,7 +30,7 @@ Below are the default key bindings for commonly used features supported in the e
 
 ### Other Features
 
-- The Motoko VS Code extension provides schema validation and autocompletion for `dfx.json` files.
+- The Motoko VS Code extension also provides schema validation and autocompletion for `dfx.json` files.
 - Hover over almost anything to view type information and/or explanations from `///` doc comments.
 - The extension automatically detects Motoko packages from [MOPS](https://mops.one/) and [Vessel](https://github.com/dfinity/vessel) config files. 
 - In case you're hoping to learn Motoko without downloading `dfx`, the Motoko VS Code extension works on all major operating systems (including Windows). 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -8,15 +8,15 @@ The [Motoko VS Code extension](https://github.com/dfinity/vscode-motoko) provide
 
 [![Showcase](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/intro.webp)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 
+Try the extension online with a full-stack [Vite + React + Motoko](https://github.com/rvanasa/vite-react-motoko#readme) starter project:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rvanasa/vite-react-motoko)
+
 ### Getting Started
 
 Install the extension through the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko), or alternatively the [Extensions panel](https://code.visualstudio.com/docs/editor/extension-marketplace) in your VS Code project. 
 
 [VSCodium](https://vscodium.com/) users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
-
-Alternatively, try out the extension online in this full-stack [Vite + React + Motoko](https://github.com/rvanasa/vite-react-motoko#readme) starter project:
-
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rvanasa/vite-react-motoko)
 
 ### Keyboard Shortcuts
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -1,12 +1,12 @@
-# VS Code extensions for Internet Computer developers
+# Visual Studio Code
 
 Visual Studio (VS) Code is a [widely used](https://survey.stackoverflow.co/2022/#section-worked-with-vs-want-to-work-with-integrated-development-environment) open-source IDE which supports canister development in [Motoko](https://internetcomputer.org/docs/current/developer-docs/build/cdks/motoko-dfinity/motoko/) and [Rust](https://www.rust-lang.org/).
 
 ## Motoko
 
-[![Showcase](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/intro.webp)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
-
 The [Motoko VS Code extension](https://github.com/dfinity/vscode-motoko) provides type checking, formatting, autocompletion, go-to-definition, code snippets, and more for Motoko canister development.
+
+[![Showcase](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/intro.webp)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 
 ### Getting Started
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -1,6 +1,6 @@
 # VS Code extensions for Internet Computer developers
 
-Visual Studio (VS) Code is a [widely used](https://survey.stackoverflow.co/2022/#section-worked-with-vs-want-to-work-with-integrated-development-environment) open-source IDE which supports canister development in [Motoko](https://internetcomputer.org/docs/current/developer-docs/build/cdks/motoko-dfinity/motoko/) or [Rust](https://www.rust-lang.org/).
+Visual Studio (VS) Code is a [widely used](https://survey.stackoverflow.co/2022/#section-worked-with-vs-want-to-work-with-integrated-development-environment) open-source IDE which supports canister development in [Motoko](https://internetcomputer.org/docs/current/developer-docs/build/cdks/motoko-dfinity/motoko/) and [Rust](https://www.rust-lang.org/).
 
 ## Motoko
 
@@ -12,9 +12,22 @@ The [Motoko VS Code extension](https://github.com/dfinity/vscode-motoko) provide
 
 Install the extension through the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko), or alternatively the [Extensions panel](https://code.visualstudio.com/docs/editor/extension-marketplace) in your VS Code project. VSCodium users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
 
-### Feature Overview
+### Keyboard Shortcuts
 
-TODO
+Below are the default key bindings for commonly used features supported in the extension:
+
+- **Code formatter**: Press `Shift` + `Alt` + `F` to format a Motoko file using [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko).
+- **Organize imports**: Press `Shift` + `Alt` + `O` to group and sort imports at the top of your Motoko file.
+- **Import code action**: Press `Ctrl` / `Cmd` + `.` while hovering over an unresolved variable to show quick-import options. 
+- **Go to definition**: Press `F12` to jump to the definition of a local or imported identifier.
+- **IntelliSense**: Press `Ctrl` + `Space` in a Motoko file to view all available autocompletions and code snippets. 
+
+### Other Features
+
+- The Motoko VS Code extension provides schema validation and autocompletion for `dfx.json` files.
+- Hover over almost anything to view type information and/or explanations from `///` doc comments.
+- The extension automatically detects Motoko packages from [MOPS](https://mops.one/) and [Vessel](https://github.com/dfinity/vessel) config files. 
+- In case you're hoping to learn Motoko without downloading `dfx`, the Motoko VS Code extension works on all major operating systems (including Windows). 
 
 ## Rust
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -22,11 +22,11 @@ Install the extension through the [VS Marketplace](https://marketplace.visualstu
 
 Below are the default key bindings for commonly used features supported in the extension:
 
-- **Code formatter**: Press `Shift` + `Alt` + `F` to format a Motoko file using [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko).
-- **Organize imports**: Press `Shift` + `Alt` + `O` to group and sort imports at the top of your Motoko file.
-- **Import code action**: Press `Ctrl` / `Cmd` + `.` while hovering over an unresolved variable to show quick-import options. 
-- **Go to definition**: Press `F12` to jump to the definition of a local or imported identifier.
-- **IntelliSense**: Press `Ctrl` + `Space` in a Motoko file to view all available autocompletions and code snippets. 
+- **Code formatter** (`Shift` + `Alt` + `F`): format a Motoko file using [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko).
+- **Organize imports** (`Shift` + `Alt` + `O`): group and sort imports at the top of your Motoko file.
+- **Import code action** (`Ctrl/Cmd` + `.` while hovering over an unresolved variable): show import quick-fix options. 
+- **Go to definition** (`F12`): jump to the definition of a local or imported identifier.
+- **IntelliSense** (`Ctrl` + `Space`): view all available autocompletions and code snippets. 
 
 ### Other Features
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -10,7 +10,9 @@ The [Motoko VS Code extension](https://github.com/dfinity/vscode-motoko) provide
 
 ### Getting Started
 
-Install the extension through the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko), or alternatively the [Extensions panel](https://code.visualstudio.com/docs/editor/extension-marketplace) in your VS Code project. VSCodium users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
+Install the extension through the [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko), or alternatively the [Extensions panel](https://code.visualstudio.com/docs/editor/extension-marketplace) in your VS Code project. 
+
+[VSCodium](https://vscodium.com/) users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
 
 ### Keyboard Shortcuts
 

--- a/docs/developer-docs/setup/vs-code.md
+++ b/docs/developer-docs/setup/vs-code.md
@@ -20,7 +20,7 @@ Install the extension through the [VS Marketplace](https://marketplace.visualstu
 
 [VSCodium](https://vscodium.com/) users can download the extension from [Open VSX](https://open-vsx.org/extension/dfinity-foundation/vscode-motoko) or the [GitHub releases](https://github.com/dfinity/vscode-motoko/releases) page.
 
-### Keyboard Shortcuts
+## Keyboard Shortcuts
 
 Below are the default key bindings for commonly used features supported in the extension:
 
@@ -30,13 +30,17 @@ Below are the default key bindings for commonly used features supported in the e
 - **Go to definition** (`F12`): jump to the definition of a local or imported identifier.
 - **IntelliSense** (`Ctrl` + `Space`): view all available autocompletions and code snippets. 
 
-### Other Features
+[![Snippets](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/snippets.png)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 
-- View type information and documentation by hovering over function names, imports, and other expressions.
+## Other Features
+
+- [Vessel](https://github.com/dfinity/vessel) and [MOPS](https://mops.one/) (the two most popular Motoko package managers) are supported out-of-the-box in this extension. 
 - Quickly convert between Motoko types using code snippets such as `array-2-buffer` or `principal-2-text`.
 - In case you're hoping to learn Motoko without installing `dfx`, the Motoko VS Code extension works standalone on all major operating systems (including Windows). 
 - This extension also provides schema validation and autocompletion for `dfx.json` config files.
-- [Vessel](https://github.com/dfinity/vessel) and [MOPS](https://mops.one/) (the two most popular Motoko package managers) are supported out-of-the-box in this extension. 
+- View type information and documentation by hovering over function names, imports, and other expressions.
+
+[![Tooltips](https://github.com/dfinity/vscode-motoko/raw/master/guide/assets/tooltips.png)](https://marketplace.visualstudio.com/items?itemName=dfinity-foundation.vscode-motoko)
 
 ### Contributing
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,7 +23,7 @@ const sidebars = {
         id: "developer-docs/setup/index",
       },
       items: [
-        "developer-docs/setup/vs-code-plugin",
+        "developer-docs/setup/vscode",
       ]},
     {
       type: "category",

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,7 +23,7 @@ const sidebars = {
         id: "developer-docs/setup/index",
       },
       items: [
-        "developer-docs/setup/vscode",
+        "developer-docs/setup/vs-code",
       ]},
     {
       type: "category",


### PR DESCRIPTION
This PR adds a guide for setting up and using the Motoko VS Code extension. 

I also renamed the page (and updated references) to `.../setup/vs-code` and included a link to the [`rust-analyzer`](https://code.visualstudio.com/docs/languages/rust) documentation for Rust canister development. 

CI is currently breaking due to a [GHA permissions error](https://github.com/actions/first-interaction/issues/10), but the Netlify preview works as expected:

[VS Code extensions for IC development (deploy preview)](https://deploy-preview-4--vermillion-horse-439c07.netlify.app/docs/current/developer-docs/setup/vs-code)
